### PR TITLE
search query highlighting in PDF / fix issue #7

### DIFF
--- a/action/search.php
+++ b/action/search.php
@@ -62,7 +62,13 @@ class action_plugin_docsearch_search extends DokuWiki_Action_Plugin {
                 $usages = array();
             }
 
-            echo '<a href="' . ml($id) . '" title="" class="wikilink1">' . hsc($id) . '</a>:';
+			$isPDF = !strcasecmp(substr($id, -4));
+            if ($isPDF === false) {
+                echo '<a href="' . ml($id) . '" title="" class="wikilink1">' . hsc($id) . '</a>:';
+            } else {
+                echo '<a href="' . ml($id) . '#search=' . $QUERY . '" title="" class="wikilink1">' . hsc($id) . '</a>:';
+            }
+
             echo '<span class="search_cnt">' . hsc($data['hits']) . ' ' . hsc($lang['hits']) . '</span>';
             if(!empty($usages)) {
                 echo '<span class="usage">';

--- a/action/search.php
+++ b/action/search.php
@@ -62,7 +62,7 @@ class action_plugin_docsearch_search extends DokuWiki_Action_Plugin {
                 $usages = array();
             }
 
-			$isPDF = !strcasecmp(substr($id, -4));
+            $isPDF = !strcasecmp(substr($id, -4));
             if ($isPDF === false) {
                 echo '<a href="' . ml($id) . '" title="" class="wikilink1">' . hsc($id) . '</a>:';
             } else {


### PR DESCRIPTION
Takes over the search query from dokuwiki to PDF as described in http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf
At the moment, at leas Adobe Reader and PDF XChange Viewer support this. ATM firefox's internal PDF viewer pdf.js doesn't seem to support this yet, but bug reports already exist.