### PR TITLE
Language string for "usage" added

### DIFF
--- a/action/search.php
+++ b/action/search.php
@@ -62,11 +62,11 @@ class action_plugin_docsearch_search extends DokuWiki_Action_Plugin {
                 $usages = array();
             }
 
-            echo '<a href="' . ml($id) . '" title="" class="wikilink1">' . hsc($id) . '</a>:';
+            echo '<a href="' . ml($id) . '" title="" class="wikilink1">' . hsc($id) . '</a>: ';
             echo '<span class="search_cnt">' . hsc($data['hits']) . ' ' . hsc($lang['hits']) . '</span>';
             if(!empty($usages)) {
                 echo '<span class="usage">';
-                echo ', Usage: ';
+                echo ', ' . hsc($this->getLang('usage')) . ' ';
                 foreach($usages as $usage) {
                     echo html_wikilink($usage);
                 }

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -7,3 +7,4 @@
  */
 $lang['title']                 = 'Ergebnisse in Dokumenten';
 $lang['confmanager title']     = 'DocSearch';
+$lang['usage']                 = 'gefunden auf Seite';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -2,5 +2,4 @@
 
 $lang['title'] = 'Results in Documents';
 $lang['confmanager title'] = 'DocSearch';
-
-?>
+$lang['usage'] = 'Usage';


### PR DESCRIPTION
The string "usage" was not localized until now. Added the localization in action.php and the language strings for en and de