### PR TITLE
fixing path to dokuwiki's cli file

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -13,7 +13,7 @@ if(isset($argv[1])) {
 
 if(!defined('DOKU_INC')) define('DOKU_INC', realpath(dirname(__FILE__) . '/../../../') . '/');
 require_once(DOKU_INC . 'inc/init.php');
-require_once DOKU_INC . 'inc/cliopts.php';
+require_once DOKU_INC . 'inc/cli.php';
 
 
 /**


### PR DESCRIPTION
the cron file is pointing to the wrong / outdated cli interface of dokuwiki 
- line 16 of docsearch/cron.php was changed in 2011
- dokuwikis cli.php was introduced in 2014